### PR TITLE
Save configuration, extract execStatus method

### DIFF
--- a/mParticle-Apptentive/MPKitApptentive.h
+++ b/mParticle-Apptentive/MPKitApptentive.h
@@ -37,7 +37,7 @@
 
 @interface Apptentive ()
 
-- (void)setMParticleId:(NSString *)mParticleId;
+- (void)setMParticleId:(NSString *_Nonnull)mParticleId;
 
 @end
 

--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -51,12 +51,14 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
     [MParticle registerExtension:kitRegister];
 }
 
+- (MPKitExecStatus *)execStatus:(MPKitReturnCode)returnCode {
+    return [[MPKitExecStatus alloc] initWithSDKCode:self.class.kitCode returnCode:returnCode];
+}
+
 #pragma mark - MPKitInstanceProtocol methods
 
 #pragma mark Kit instance and lifecycle
 - (MPKitExecStatus *)didFinishLaunchingWithConfiguration:(NSDictionary *)configuration {
-    MPKitExecStatus *execStatus = nil;
-
     NSString *appKey = configuration[apptentiveAppKeyKey];
     NSString *appSignature = configuration[apptentiveAppSignatureKey];
 
@@ -71,16 +73,16 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
 
         NSLog(@"Please see the Apptentive mParticle integration guide: https://learn.apptentive.com/knowledge-base/mparticle-integration-ios/");
     }
-    
+
     if (!appKey || !appSignature) {
-        execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeRequirementsNotMet];
-        return execStatus;
+        return [self execStatus:MPKitReturnCodeRequirementsNotMet];
     }
+
+    _configuration = configuration;
 
     [self start];
 
-    execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
-    return execStatus;
+    return [self execStatus:MPKitReturnCodeSuccess];
 }
 
 - (void)start {
@@ -97,11 +99,11 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
 
         [Apptentive registerWithConfiguration:apptentiveConfig];
 
-        _started = YES;
+        self->_started = YES;
 
         if ([NSPersonNameComponents class]) {
-            _nameFormatter = [[NSPersonNameComponentsFormatter alloc] init];
-            _nameComponents = [[NSPersonNameComponents alloc] init];
+            self->_nameFormatter = [[NSPersonNameComponentsFormatter alloc] init];
+            self->_nameComponents = [[NSPersonNameComponents alloc] init];
         }
 
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -155,14 +157,12 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
         [Apptentive sharedConnection].personName = name;
     }
 
-    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
-    return execStatus;
+    return [self execStatus:MPKitReturnCodeSuccess];
 }
 
 - (MPKitExecStatus *)removeUserAttribute:(NSString *)key {
     [[Apptentive sharedConnection] removeCustomPersonDataWithKey:key];
-    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
-    return execStatus;
+    return [self execStatus:MPKitReturnCodeSuccess];
 }
 
 - (MPKitExecStatus *)setUserIdentity:(NSString *)identityString identityType:(MPUserIdentity)identityType {
@@ -180,8 +180,7 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
         returnCode = MPKitReturnCodeRequirementsNotMet;
     }
 
-    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:returnCode];
-    return execStatus;
+    return [self execStatus:returnCode];
 }
 
 #pragma mark e-Commerce
@@ -242,8 +241,7 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
     } else {
         [[Apptentive sharedConnection] engage:event.name fromViewController:nil];
     }
-    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
-    return execStatus;
+    return [self execStatus:MPKitReturnCodeSuccess];
 }
 
 #pragma mark Conversation state


### PR DESCRIPTION
JIRA issue: https://apptentive.atlassian.net/browse/SEA-780

Currently the mParticle kit example (https://github.com/mparticle-integrations/mparticle-apple-integration-example/blob/3fcf5eb5027e50cb07ceefb94403f44bf8f8004f/mParticle-Example/MPKitExample.m#L38) has a step that saves the configuration inside of the kit code. I assume that previously they had a way of saving it upstream of the kit, and that that had been removed. 

That means that the current Apptentive iOS kit isn't able to pull the app key and app signature from the configuration object in the `-start` method, causing the SDK to fail to launch and logging an error.

This PR saves the configuration to a instance variable to fix this. 

It also borrows from the above example code to extract the status message return into a method. This should keep our code more in line with the example code that mParticle provides. 

