### PR TITLE
Custom data parsing + screen events

### DIFF
--- a/mParticle-Apptentive.xcodeproj/project.pbxproj
+++ b/mParticle-Apptentive.xcodeproj/project.pbxproj
@@ -12,7 +12,19 @@
 		DB7E05A71CB819D300967FDF /* MPKitApptentive.m in Sources */ = {isa = PBXBuildFile; fileRef = DB7E05A51CB819D300967FDF /* MPKitApptentive.m */; };
 		DB9401701CB703F2007ABB18 /* mParticle_Apptentive.h in Headers */ = {isa = PBXBuildFile; fileRef = DB94016F1CB703F2007ABB18 /* mParticle_Apptentive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB94017A1CB70C58007ABB18 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB9401781CB70C58007ABB18 /* mParticle_Apple_SDK.framework */; };
+		EF233800263F3F0F004B1C55 /* mParticle_ApptentiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EF2337FF263F3F0F004B1C55 /* mParticle_ApptentiveTests.m */; };
+		EF233802263F3F0F004B1C55 /* mParticle_Apptentive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB94016C1CB703F2007ABB18 /* mParticle_Apptentive.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		EF233803263F3F0F004B1C55 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB9401631CB703F2007ABB18 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DB94016B1CB703F2007ABB18;
+			remoteInfo = "mParticle-Apptentive";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		DB695FB21F5F549A00A7F4CF /* Apptentive.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Apptentive.framework; path = Carthage/Build/iOS/Apptentive.framework; sourceTree = "<group>"; };
@@ -22,6 +34,9 @@
 		DB94016F1CB703F2007ABB18 /* mParticle_Apptentive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mParticle_Apptentive.h; sourceTree = "<group>"; };
 		DB9401711CB703F2007ABB18 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DB9401781CB70C58007ABB18 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
+		EF2337FD263F3F0F004B1C55 /* mParticle-ApptentiveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mParticle-ApptentiveTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF2337FF263F3F0F004B1C55 /* mParticle_ApptentiveTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = mParticle_ApptentiveTests.m; sourceTree = "<group>"; };
+		EF233801263F3F0F004B1C55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -34,6 +49,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EF2337FA263F3F0F004B1C55 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF233802263F3F0F004B1C55 /* mParticle_Apptentive.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -43,6 +66,7 @@
 				DB695FB21F5F549A00A7F4CF /* Apptentive.framework */,
 				DB9401781CB70C58007ABB18 /* mParticle_Apple_SDK.framework */,
 				DB94016E1CB703F2007ABB18 /* mParticle-Apptentive */,
+				EF2337FE263F3F0F004B1C55 /* mParticle-ApptentiveTests */,
 				DB94016D1CB703F2007ABB18 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -51,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				DB94016C1CB703F2007ABB18 /* mParticle_Apptentive.framework */,
+				EF2337FD263F3F0F004B1C55 /* mParticle-ApptentiveTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -64,6 +89,15 @@
 				DB9401711CB703F2007ABB18 /* Info.plist */,
 			);
 			path = "mParticle-Apptentive";
+			sourceTree = "<group>";
+		};
+		EF2337FE263F3F0F004B1C55 /* mParticle-ApptentiveTests */ = {
+			isa = PBXGroup;
+			children = (
+				EF2337FF263F3F0F004B1C55 /* mParticle_ApptentiveTests.m */,
+				EF233801263F3F0F004B1C55 /* Info.plist */,
+			);
+			path = "mParticle-ApptentiveTests";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -99,6 +133,24 @@
 			productReference = DB94016C1CB703F2007ABB18 /* mParticle_Apptentive.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		EF2337FC263F3F0F004B1C55 /* mParticle-ApptentiveTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF233807263F3F0F004B1C55 /* Build configuration list for PBXNativeTarget "mParticle-ApptentiveTests" */;
+			buildPhases = (
+				EF2337F9263F3F0F004B1C55 /* Sources */,
+				EF2337FA263F3F0F004B1C55 /* Frameworks */,
+				EF2337FB263F3F0F004B1C55 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF233804263F3F0F004B1C55 /* PBXTargetDependency */,
+			);
+			name = "mParticle-ApptentiveTests";
+			productName = "mParticle-ApptentiveTests";
+			productReference = EF2337FD263F3F0F004B1C55 /* mParticle-ApptentiveTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -112,6 +164,11 @@
 						CreatedOnToolsVersion = 7.3;
 						DevelopmentTeam = Q948K5LXGZ;
 					};
+					EF2337FC263F3F0F004B1C55 = {
+						CreatedOnToolsVersion = 12.3;
+						DevelopmentTeam = 94Z94R59HQ;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = DB9401661CB703F2007ABB18 /* Build configuration list for PBXProject "mParticle-Apptentive" */;
@@ -119,6 +176,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = DB9401621CB703F2007ABB18;
@@ -127,12 +185,20 @@
 			projectRoot = "";
 			targets = (
 				DB94016B1CB703F2007ABB18 /* mParticle-Apptentive */,
+				EF2337FC263F3F0F004B1C55 /* mParticle-ApptentiveTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		DB94016A1CB703F2007ABB18 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF2337FB263F3F0F004B1C55 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -150,7 +216,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EF2337F9263F3F0F004B1C55 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF233800263F3F0F004B1C55 /* mParticle_ApptentiveTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		EF233804263F3F0F004B1C55 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DB94016B1CB703F2007ABB18 /* mParticle-Apptentive */;
+			targetProxy = EF233803263F3F0F004B1C55 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		DB9401721CB703F2007ABB18 /* Debug */ = {
@@ -308,6 +390,51 @@
 			};
 			name = Release;
 		};
+		EF233805263F3F0F004B1C55 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 94Z94R59HQ;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "mParticle-ApptentiveTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.apptentive.mParticle-ApptentiveTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		EF233806263F3F0F004B1C55 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 94Z94R59HQ;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "mParticle-ApptentiveTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.apptentive.mParticle-ApptentiveTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -325,6 +452,15 @@
 			buildConfigurations = (
 				DB9401751CB703F2007ABB18 /* Debug */,
 				DB9401761CB703F2007ABB18 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EF233807263F3F0F004B1C55 /* Build configuration list for PBXNativeTarget "mParticle-ApptentiveTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF233805263F3F0F004B1C55 /* Debug */,
+				EF233806263F3F0F004B1C55 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/mParticle-Apptentive.xcodeproj/project.pbxproj
+++ b/mParticle-Apptentive.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		DB94017A1CB70C58007ABB18 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB9401781CB70C58007ABB18 /* mParticle_Apple_SDK.framework */; };
 		EF233800263F3F0F004B1C55 /* mParticle_ApptentiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EF2337FF263F3F0F004B1C55 /* mParticle_ApptentiveTests.m */; };
 		EF233802263F3F0F004B1C55 /* mParticle_Apptentive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB94016C1CB703F2007ABB18 /* mParticle_Apptentive.framework */; };
+		EF23381E263F48B2004B1C55 /* MPKitApptentiveUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = EF23381C263F48B2004B1C55 /* MPKitApptentiveUtils.h */; };
+		EF23381F263F48B2004B1C55 /* MPKitApptentiveUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EF23381D263F48B2004B1C55 /* MPKitApptentiveUtils.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,6 +39,8 @@
 		EF2337FD263F3F0F004B1C55 /* mParticle-ApptentiveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mParticle-ApptentiveTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF2337FF263F3F0F004B1C55 /* mParticle_ApptentiveTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = mParticle_ApptentiveTests.m; sourceTree = "<group>"; };
 		EF233801263F3F0F004B1C55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EF23381C263F48B2004B1C55 /* MPKitApptentiveUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPKitApptentiveUtils.h; sourceTree = "<group>"; };
+		EF23381D263F48B2004B1C55 /* MPKitApptentiveUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPKitApptentiveUtils.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +89,8 @@
 			children = (
 				DB7E05A41CB819D300967FDF /* MPKitApptentive.h */,
 				DB7E05A51CB819D300967FDF /* MPKitApptentive.m */,
+				EF23381C263F48B2004B1C55 /* MPKitApptentiveUtils.h */,
+				EF23381D263F48B2004B1C55 /* MPKitApptentiveUtils.m */,
 				DB94016F1CB703F2007ABB18 /* mParticle_Apptentive.h */,
 				DB9401711CB703F2007ABB18 /* Info.plist */,
 			);
@@ -109,6 +115,7 @@
 			files = (
 				DB9401701CB703F2007ABB18 /* mParticle_Apptentive.h in Headers */,
 				DB7E05A61CB819D300967FDF /* MPKitApptentive.h in Headers */,
+				EF23381E263F48B2004B1C55 /* MPKitApptentiveUtils.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -213,6 +220,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DB7E05A71CB819D300967FDF /* MPKitApptentive.m in Sources */,
+				EF23381F263F48B2004B1C55 /* MPKitApptentiveUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mParticle-Apptentive.xcodeproj/project.pbxproj
+++ b/mParticle-Apptentive.xcodeproj/project.pbxproj
@@ -411,7 +411,6 @@
 				DEVELOPMENT_TEAM = 94Z94R59HQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "mParticle-ApptentiveTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -434,7 +433,6 @@
 				DEVELOPMENT_TEAM = 94Z94R59HQ;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "mParticle-ApptentiveTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.apptentive.mParticle-ApptentiveTests";

--- a/mParticle-Apptentive.xcodeproj/xcshareddata/xcschemes/mParticle-Apptentive.xcscheme
+++ b/mParticle-Apptentive.xcodeproj/xcshareddata/xcschemes/mParticle-Apptentive.xcscheme
@@ -28,9 +28,17 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF2337FC263F3F0F004B1C55"
+               BuildableName = "mParticle-ApptentiveTests.xctest"
+               BlueprintName = "mParticle-ApptentiveTests"
+               ReferencedContainer = "container:mParticle-Apptentive.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +59,6 @@
             ReferencedContainer = "container:mParticle-Apptentive.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -42,6 +42,26 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
 
 @end
 
+@interface Apptentive (CustomData)
+
+- (void)addCustomPersonData:(id)value withKey:(NSString *)key;
+
+@end
+
+@implementation Apptentive (CustomData)
+
+- (void)addCustomPersonData:(id)value withKey:(NSString *)key {
+    if ([value isKindOfClass:[NSString class]]) {
+        [[Apptentive sharedConnection] addCustomPersonDataString:value withKey:key];
+    } else if ([value isKindOfClass:[NSNumber class]]) {
+        [[Apptentive sharedConnection] addCustomPersonDataNumber:value withKey:key];
+    } else {
+        NSLog(@"Unexpected custom data type: %@", [value class]);
+    }
+}
+
+@end
+
 @implementation MPKitApptentive
 
 + (NSNumber *)kitCode {
@@ -138,7 +158,7 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
             self.lastName = value;
         }
     } else {
-        [[Apptentive sharedConnection] addCustomPersonDataString:value withKey:key];
+        [[Apptentive sharedConnection] addCustomPersonData:MPKitApptentiveParseValue(value) withKey:key];
     }
 
     NSString *name = nil;
@@ -239,7 +259,7 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
 - (MPKitExecStatus *)logEvent:(MPEvent *)event {
     NSDictionary *eventValues = MPKitApptentiveParseEventInfo(event.info);
     if ([eventValues count] > 0) {
-        [[Apptentive sharedConnection] engage:event.name withCustomData:eventValues fromViewController:nil];
+        [[Apptentive sharedConnection] engage:event.name withCustomData:MPKitApptentiveParseEventInfo(eventValues) fromViewController:nil];
     } else {
         [[Apptentive sharedConnection] engage:event.name fromViewController:nil];
     }

--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -257,13 +257,19 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
 #pragma mark Events
 
 - (MPKitExecStatus *)logEvent:(MPEvent *)event {
-    NSDictionary *eventValues = MPKitApptentiveParseEventInfo(event.info);
+    NSDictionary *eventValues = event.info;
     if ([eventValues count] > 0) {
         [[Apptentive sharedConnection] engage:event.name withCustomData:MPKitApptentiveParseEventInfo(eventValues) fromViewController:nil];
     } else {
         [[Apptentive sharedConnection] engage:event.name fromViewController:nil];
     }
     return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+#pragma mark Screen Events
+
+- (MPKitExecStatus *)logScreen:(MPEvent *)event {
+    return [self logEvent:event];
 }
 
 #pragma mark Conversation state

--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -24,6 +24,8 @@
 #import "Apptentive.h"
 #endif
 
+#import "MPKitApptentiveUtils.h"
+
 NSString * const apptentiveAppKeyKey = @"apptentiveAppKey";
 NSString * const apptentiveAppSignatureKey = @"apptentiveAppSignature";
 NSString * const ApptentiveConversationStateDidChangeNotification = @"ApptentiveConversationStateDidChangeNotification";
@@ -235,7 +237,7 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
 #pragma mark Events
 
 - (MPKitExecStatus *)logEvent:(MPEvent *)event {
-    NSDictionary *eventValues = event.info;
+    NSDictionary *eventValues = MPKitApptentiveParseEventInfo(event.info);
     if ([eventValues count] > 0) {
         [[Apptentive sharedConnection] engage:event.name withCustomData:eventValues fromViewController:nil];
     } else {

--- a/mParticle-Apptentive/MPKitApptentiveUtils.h
+++ b/mParticle-Apptentive/MPKitApptentiveUtils.h
@@ -10,6 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+id MPKitApptentiveParseValue(NSString *value);
 NSDictionary* MPKitApptentiveParseEventInfo(NSDictionary *info);
 
 NS_ASSUME_NONNULL_END

--- a/mParticle-Apptentive/MPKitApptentiveUtils.h
+++ b/mParticle-Apptentive/MPKitApptentiveUtils.h
@@ -1,0 +1,15 @@
+//
+//  MPKitApptentiveUtils.h
+//  mParticle-Apptentive
+//
+//  Created by Alex Lementuev on 5/2/21.
+//  Copyright © 2021 mParticle. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NSDictionary* MPKitApptentiveParseEventInfo(NSDictionary *info);
+
+NS_ASSUME_NONNULL_END

--- a/mParticle-Apptentive/MPKitApptentiveUtils.m
+++ b/mParticle-Apptentive/MPKitApptentiveUtils.m
@@ -17,7 +17,7 @@ static NSNumber *parseNumber(NSString *str) {
     return [formatter numberFromString:str];
 }
 
-static id parseValue(NSString *value) {
+id MPKitApptentiveParseValue(NSString *value) {
     if ([value caseInsensitiveCompare:@"true"] == NSOrderedSame) {
         return [NSNumber numberWithBool:YES];
     }
@@ -38,7 +38,7 @@ NSDictionary* MPKitApptentiveParseEventInfo(NSDictionary *info) {
     NSMutableDictionary *res = [[NSMutableDictionary alloc] init];
     for (id key in info) {
         id value = info[key];
-        res[key] = [value isKindOfClass:[NSString class]] ? parseValue(value) : value;
+        res[key] = [value isKindOfClass:[NSString class]] ? MPKitApptentiveParseValue(value) : value;
     }
     return res;
 }

--- a/mParticle-Apptentive/MPKitApptentiveUtils.m
+++ b/mParticle-Apptentive/MPKitApptentiveUtils.m
@@ -8,13 +8,27 @@
 
 #import "MPKitApptentiveUtils.h"
 
-static id parseValue(id value) {
-    if ([value caseInsensitiveCompare:@"true"]) {
+static NSNumber *parseNumber(NSString *str) {
+    static NSNumberFormatter *formatter = nil;
+    if (!formatter) {
+        formatter = [[NSNumberFormatter alloc] init];
+    }
+    
+    return [formatter numberFromString:str];
+}
+
+static id parseValue(NSString *value) {
+    if ([value caseInsensitiveCompare:@"true"] == NSOrderedSame) {
         return [NSNumber numberWithBool:YES];
     }
     
-    if ([value caseInsensitiveCompare:@"false"]) {
+    if ([value caseInsensitiveCompare:@"false"] == NSOrderedSame) {
         return [NSNumber numberWithBool:NO];
+    }
+    
+    NSNumber *number = parseNumber(value);
+    if (number) {
+        return number;
     }
     
     return value;

--- a/mParticle-Apptentive/MPKitApptentiveUtils.m
+++ b/mParticle-Apptentive/MPKitApptentiveUtils.m
@@ -9,18 +9,22 @@
 #import "MPKitApptentiveUtils.h"
 
 static id parseValue(id value) {
-    if ([value isKindOfClass:[NSString class]]) {
-    } else {
+    if ([value caseInsensitiveCompare:@"true"]) {
+        return [NSNumber numberWithBool:YES];
     }
     
-    return nil;
+    if ([value caseInsensitiveCompare:@"false"]) {
+        return [NSNumber numberWithBool:NO];
+    }
+    
+    return value;
 }
 
 NSDictionary* MPKitApptentiveParseEventInfo(NSDictionary *info) {
     NSMutableDictionary *res = [[NSMutableDictionary alloc] init];
     for (id key in info) {
         id value = info[key];
-        res[key] = parseValue(value);
+        res[key] = [value isKindOfClass:[NSString class]] ? parseValue(value) : value;
     }
     return res;
 }

--- a/mParticle-Apptentive/MPKitApptentiveUtils.m
+++ b/mParticle-Apptentive/MPKitApptentiveUtils.m
@@ -1,0 +1,26 @@
+//
+//  MPKitApptentiveUtils.m
+//  mParticle-Apptentive
+//
+//  Created by Alex Lementuev on 5/2/21.
+//  Copyright © 2021 mParticle. All rights reserved.
+//
+
+#import "MPKitApptentiveUtils.h"
+
+static id parseValue(id value) {
+    if ([value isKindOfClass:[NSString class]]) {
+    } else {
+    }
+    
+    return nil;
+}
+
+NSDictionary* MPKitApptentiveParseEventInfo(NSDictionary *info) {
+    NSMutableDictionary *res = [[NSMutableDictionary alloc] init];
+    for (id key in info) {
+        id value = info[key];
+        res[key] = parseValue(value);
+    }
+    return res;
+}

--- a/mParticle-ApptentiveTests/Info.plist
+++ b/mParticle-ApptentiveTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/mParticle-ApptentiveTests/mParticle_ApptentiveTests.m
+++ b/mParticle-ApptentiveTests/mParticle_ApptentiveTests.m
@@ -8,30 +8,55 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MPKitApptentiveUtils.h"
+
 @interface mParticle_ApptentiveTests : XCTestCase
 
 @end
 
 @implementation mParticle_ApptentiveTests
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
+- (void)testMPKitApptentiveParseEventInfo {
+    NSDictionary *data = @{
+        // boolean
+        @"key-1": @"true",
+        @"key-2": @"True",
+        @"key-3": @"false",
+        @"key-4": @"False",
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
+        // integer
+        @"key-5": @"12345",
+        @"key-6": @"-12345",
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
-}
+        // double
+        @"key-7": @"3.14",
+        @"key-8": @"-3.14",
 
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+        // string
+        @"key-9": @"test"
+    };
+    
+    NSDictionary *expected = @{
+        // boolean
+        @"key-1": @YES,
+        @"key-2": @YES,
+        @"key-3": @NO,
+        @"key-4": @NO,
+
+        // integer
+        @"key-5": @12345,
+        @"key-6": @-12345,
+
+        // double
+        @"key-7": @3.14,
+        @"key-8": @-3.14,
+
+        // string
+        @"key-9": @"test",
+    };
+
+    NSDictionary *actual = MPKitApptentiveParseEventInfo(data);
+    XCTAssertEqualObjects(expected, actual);
 }
 
 @end

--- a/mParticle-ApptentiveTests/mParticle_ApptentiveTests.m
+++ b/mParticle-ApptentiveTests/mParticle_ApptentiveTests.m
@@ -1,0 +1,37 @@
+//
+//  mParticle_ApptentiveTests.m
+//  mParticle-ApptentiveTests
+//
+//  Created by Alex Lementuev on 5/2/21.
+//  Copyright © 2021 mParticle. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface mParticle_ApptentiveTests : XCTestCase
+
+@end
+
+@implementation mParticle_ApptentiveTests
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/mParticle-ApptentiveTests/mParticle_ApptentiveTests.m
+++ b/mParticle-ApptentiveTests/mParticle_ApptentiveTests.m
@@ -33,7 +33,8 @@
         @"key-8": @"-3.14",
 
         // string
-        @"key-9": @"test"
+        @"key-9": @"123test456"
+        
     };
     
     NSDictionary *expected = @{
@@ -52,7 +53,7 @@
         @"key-8": @-3.14,
 
         // string
-        @"key-9": @"test",
+        @"key-9": @"123test456",
     };
 
     NSDictionary *actual = MPKitApptentiveParseEventInfo(data);


### PR DESCRIPTION
mParticle passes user attribute data as `NSDictionary<NSString*, NSString*>*` but the platform needs to work with numeric, string, and boolean types. An easy workaround is to attempt to parse string values into valid boolean and numbers or fall back to string values if not applicable.  
Screen events are passed as-is